### PR TITLE
NodistをNVMに変更

### DIFF
--- a/installs/data/windows_chocolatey-packages.config
+++ b/installs/data/windows_chocolatey-packages.config
@@ -14,8 +14,8 @@
   <package id="InkScape" />
   <package id="jdk8" />
   <package id="mpc-hc" />
-  <package id="nodist" />
   <package id="notepadplusplus.install" />
+  <package id="nvm" />
   <package id="openssh" />
   <package id="tiled" />
   <package id="visualstudiocode" />


### PR DESCRIPTION
なんで
- Nodist の調子がおかしい
  - `npm` のアップデートがそのままではできない
  - Nodist の `nodist npm match` でアップデートしたところ、 npm や Nodist を起動したところ、`Cannot find module npm-cli.js` とエラーが発生
  - と言った感じで Node の実行環境が壊れた
- 修正に手間が掛かることと、代わりの Node のバージョン切り替えシステムとして NVM-Windows がよく利用されていることから、 NVM(-Windows) に変更